### PR TITLE
Add CSS module for IconPreviewArea

### DIFF
--- a/src/components/IconPreviewArea/IconPreviewArea.module.css
+++ b/src/components/IconPreviewArea/IconPreviewArea.module.css
@@ -1,0 +1,16 @@
+.IconPreviewArea {
+  padding: 50px 0;
+}
+
+.IconList {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, 100px);
+  justify-content: center;
+  gap: 20px;
+  margin: 50px 80px;
+}
+
+.IconList svg {
+  max-width: 40px;
+  max-height: 40px;
+}

--- a/src/components/IconPreviewArea/IconPreviewArea.scss
+++ b/src/components/IconPreviewArea/IconPreviewArea.scss
@@ -1,6 +1,0 @@
-.IconPreviewArea {
-  display: flex;
-  margin: 10px;
-  justify-content: center;
-  flex-wrap: wrap;
-}

--- a/src/components/IconPreviewArea/index.jsx
+++ b/src/components/IconPreviewArea/index.jsx
@@ -1,12 +1,17 @@
-import "./IconPreviewArea.scss";
+import styles from "./IconPreviewArea.module.css";
+
 import IconPreview from "../IconPreview";
+import Upload from "../Upload";
 
 export default function IconPreviewArea({ icons, setIcons }) {
   return (
-    <div className="IconPreviewArea">
-      {icons.map((icon) => (
-        <IconPreview icon={icon} icons={icons} setIcons={setIcons} />
-      ))}
+    <div className={styles.IconPreviewArea}>
+      <div className={styles.IconList}>
+        {icons.map((icon) => (
+          <IconPreview icon={icon} icons={icons} setIcons={setIcons} />
+        ))}
+      </div>
+      <Upload />
     </div>
   );
 }


### PR DESCRIPTION
Removed the previous SCSS styles of IconPreviewArea and replaced it with CSS modules. Changed the classNames accordingly. 