### PR TITLE
Fix upload problem (UploadWrapper)

### DIFF
--- a/src/components/UploadWrapper/index.jsx
+++ b/src/components/UploadWrapper/index.jsx
@@ -1,4 +1,5 @@
 import { useRef } from "react";
+import toast from "react-hot-toast";
 
 import extractFiles from "src/utils/extractFiles";
 
@@ -20,6 +21,10 @@ const UploadWrapper = ({ icons, setIcons, children }) => {
       ({ name }) => !oldIcons.find((oldIcon) => oldIcon.name === name)
     );
 
+    if (newIcons.length) {
+      toast.success("Upload successful!");
+    }
+
     setIcons([...oldIcons, ...newIcons]);
   };
 
@@ -28,9 +33,14 @@ const UploadWrapper = ({ icons, setIcons, children }) => {
     fileInput?.current?.click();
   };
 
+  // If a deleted icon is re-imported, the import will not work stable.
+  // "onChange" event doesn't work at all. This key was required to fix this issue.
+  const inputKey = JSON.stringify(icons);
+
   return (
     <label>
       <input
+        key={inputKey}
         style={{ display: "none" }}
         ref={fileInput}
         type="file"

--- a/src/utils/extractFiles.js
+++ b/src/utils/extractFiles.js
@@ -34,10 +34,6 @@ const extractFiles = async (event) => {
     });
   }
 
-  if (selectedIcons.length) {
-    toast.success("Upload successful!");
-  }
-
   return selectedIcons;
 };
 


### PR DESCRIPTION
**Fixed:** If a deleted icon is re-imported, the import will not work stable.  
**Fixed:** If an already existing icon is imported, successful notification will be displayed.