### PR TITLE
#227 Fix svg name overflowing in the edit popup

### DIFF
--- a/src/components/IconSetPreviewInspect.tsx
+++ b/src/components/IconSetPreviewInspect.tsx
@@ -59,7 +59,7 @@ const IconSetPreviewInspect = ({
             >
               <Dialog.Panel className="w-auto max-w-md transform overflow-hidden rounded-2xl bg-neutral-100 p-8 text-left align-middle shadow-xl transition-all dark:bg-neutral-800">
                 <div className="min-h-20 flex w-full flex-col-reverse items-start justify-between divide-neutral-300 dark:divide-neutral-700 sm:flex-row sm:divide-x">
-                  <div className="mt-4 flex w-full flex-col items-center justify-center sm:mt-0  sm:items-start sm:pr-8">
+                  <div className="mt-4 flex w-full flex-col items-center justify-center sm:mt-0  sm:items-start sm:pr-4">
                     <Icon
                       icon="close"
                       size={16}
@@ -113,7 +113,7 @@ const IconSetPreviewInspect = ({
                       className="mt-2 inline-flex cursor-pointer items-center"
                       onClick={handleCopyIconName}
                     >
-                      {inspectedIcon?.properties.name}
+                      <p className="truncate ... max-w-[160px]">{inspectedIcon?.properties.name}</p>
                       <Icon
                         icon="copy"
                         size={14}


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/32804505/197410814-5783ac87-21d8-44ce-b665-a9e33c17eba3.png)


![image](https://user-images.githubusercontent.com/32804505/197410840-bd2fed63-4af0-4831-b112-875fab902c50.png)

after update  `pr-8` as a `pr-4`

```diff
- <div className="mt-4 flex w-full flex-col items-center justify-center sm:mt-0  sm:items-start sm:pr-8">
+ <div className="mt-4 flex w-full flex-col items-center justify-center sm:mt-0  sm:items-start sm:pr-4">
```

![image](https://user-images.githubusercontent.com/32804505/197410794-9019167b-438c-4d8b-af5d-49ae0dfa343c.png)


Closes #227 