### PR TITLE
Fix wrapping issue when selected size is 120x120

### DIFF
--- a/src/components/SelectSize.tsx
+++ b/src/components/SelectSize.tsx
@@ -25,7 +25,7 @@ const SelectSize = ({ size, setSize }: SelectSizeProps) => {
         className="w-full px-0 sm:w-auto"
       >
         Size:{" "}
-        <span className="ml-2 text-neutral-900 dark:text-neutral-100">
+        <span className="ml-2 text-neutral-900 dark:text-neutral-100 whitespace-nowrap">
           {size} x {size}
         </span>
         <Icon icon="chevron-down" size={16} className="ml-1"></Icon>


### PR DESCRIPTION
Selected icon size text was wrapping when it is 120x120. I thought this was an issue and created this pr :) 

Old Behaviour: 
![Ekran Resmi 2022-11-04 10 21 15](https://user-images.githubusercontent.com/49235488/199915780-611edfb0-6be1-4c06-b2d8-2db9fa7242f2.png)

New Behaviour:
![Ekran Resmi 2022-11-04 10 20 53](https://user-images.githubusercontent.com/49235488/199915649-2f2cd5e3-9f06-40d2-ab83-36babf134988.png)

