### PR TITLE
Fix IconSetPreviewFooter section colors are not matching problem.

### DIFF
--- a/src/components/IconSetPreviewFooter.tsx
+++ b/src/components/IconSetPreviewFooter.tsx
@@ -105,7 +105,6 @@ const IconSetPreviewFooter = ({
                 <Tooltip message="Send to App">
                   <Button
                     variant={ButtonVariants.Icon}
-                    className="text-orange-400 hover:text-orange-300"
                     onClick={handleSendToAppSelected}
                   >
                     <Icon icon="window-plus" size={20} />
@@ -161,7 +160,6 @@ const IconSetPreviewFooter = ({
               <Tooltip message="Send to App">
                 <Button
                   variant={ButtonVariants.Icon}
-                  className="text-orange-400 hover:text-orange-300"
                   onClick={handleSendToAppAll}
                 >
                   <Icon icon="window-plus" size={20} />


### PR DESCRIPTION
Fix IconSetPreviewFoooter icons not matching the section colors issue.
- Before:
<img width="300" alt="Ekran Resmi 2022-11-26 17 40 53" src="https://cdn.discordapp.com/attachments/807674119952138250/1046058286564266114/image.png">
- After:
<img width="300" alt="Ekran Resmi 2022-11-26 17 40 53" src="https://user-images.githubusercontent.com/49235488/204094497-e991b8fc-30a0-4416-871b-0ce0cfa6f68d.png">

