### PR TITLE
Update: Improve button variants.

### DIFF
--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -1,29 +1,20 @@
 import { ButtonHTMLAttributes } from "react";
 import clsx from "clsx";
 
-export enum ButtonVariants {
-  Primary = "primary",
-  Secondary = "secondary",
-  Success = "success",
-  Ghost = "ghost",
-  Icon = "icon",
-}
-
 const variants = {
-  [ButtonVariants.Primary]:
+  primary:
     "text-white bg-purple-500 hover:bg-purple-600 shadow-md focus:ring-purple-500",
-  [ButtonVariants.Secondary]:
+  secondary:
     "text-white bg-sky-500 hover:bg-sky-600 shadow-md focus:ring-sky-500",
-  [ButtonVariants.Success]:
+  success:
     "text-white bg-green-500 hover:bg-green-600 shadow-md focus:ring-green-500",
-  [ButtonVariants.Ghost]:
+  ghost:
     "text-neutral-700 dark:text-neutral-400 hover:text-neutral-900 dark:hover:text-gray-300 focus:ring-gray-500 shadow-none",
-  [ButtonVariants.Icon]:
-    "focus:ring-gray-500 shadow-none !px-2 border border-dashed !border-neutral-300 dark:!border-neutral-700 opacity-100 hover:opacity-70",
+  icon: "focus:ring-gray-500 shadow-none !px-2 border border-dashed !border-neutral-300 dark:!border-neutral-700 opacity-100 hover:opacity-70",
 };
 
 interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
-  variant?: ButtonVariants;
+  variant?: keyof typeof variants;
 }
 
 const Button = ({ children, className, variant, ...props }: ButtonProps) => (

--- a/src/components/Dialog.tsx
+++ b/src/components/Dialog.tsx
@@ -1,7 +1,7 @@
 import { Fragment } from "react";
 import { Dialog, Transition } from "@headlessui/react";
 
-import Button, { ButtonVariants } from "src/components/Button";
+import Button from "src/components/Button";
 
 interface DialogProps {
   title?: string;
@@ -64,10 +64,10 @@ const DialogComponent = ({
                 )}
 
                 <div className="mt-8 flex justify-center gap-4">
-                  <Button variant={ButtonVariants.Ghost} onClick={closeDialog}>
+                  <Button variant="ghost" onClick={closeDialog}>
                     Cancel
                   </Button>
-                  <Button variant={ButtonVariants.Primary} onClick={onConfirm}>
+                  <Button variant="primary" onClick={onConfirm}>
                     Yes
                   </Button>
                 </div>

--- a/src/components/ExportButton.tsx
+++ b/src/components/ExportButton.tsx
@@ -1,21 +1,20 @@
-import { ButtonHTMLAttributes } from "react";
+import { ComponentProps } from "react";
 import { klona } from "klona";
 import clsx from "clsx";
 
-import Button, { ButtonVariants } from "src/components/Button";
+import Button from "src/components/Button";
 import { convertToIconSet } from "src/utils/convertToIconSet";
 import { IconSetItem } from "src/types";
 
-interface ExportButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+interface ExportButtonProps extends ComponentProps<typeof Button> {
   icons: IconSetItem[];
-  variant?: ButtonVariants;
 }
 
 const ExportButton = ({
   icons,
-  variant,
   children,
   className,
+  ...props
 }: ExportButtonProps) => {
   const onClick = () => {
     const formattedIcons = convertToIconSet(
@@ -38,8 +37,8 @@ const ExportButton = ({
   return (
     <Button
       className={clsx("w-full sm:w-auto", className)}
-      variant={variant}
       onClick={onClick}
+      {...props}
     >
       {children}
     </Button>

--- a/src/components/IconSetPreviewFooter.tsx
+++ b/src/components/IconSetPreviewFooter.tsx
@@ -1,7 +1,7 @@
 import { useContext, useState } from "react";
 
 import Icon from "src/components/Icon";
-import Button, { ButtonVariants } from "src/components/Button";
+import Button from "src/components/Button";
 import ExportButton from "src/components/ExportButton";
 import Tooltip from "src/components/Tooltip";
 import Dialog from "src/components/Dialog";
@@ -93,10 +93,7 @@ const IconSetPreviewFooter = ({
               </span>
               {isApp && (
                 <Tooltip message="Remove Selected">
-                  <Button
-                    variant={ButtonVariants.Icon}
-                    onClick={handleRemoveSelected}
-                  >
+                  <Button variant="icon" onClick={handleRemoveSelected}>
                     <Icon icon="trash" size={20} />
                   </Button>
                 </Tooltip>
@@ -104,7 +101,7 @@ const IconSetPreviewFooter = ({
               {!isApp && (
                 <Tooltip message="Send to App">
                   <Button
-                    variant={ButtonVariants.Icon}
+                    variant="icon"
                     className="text-orange-400 hover:text-orange-300"
                     onClick={handleSendToAppSelected}
                   >
@@ -113,28 +110,19 @@ const IconSetPreviewFooter = ({
                 </Tooltip>
               )}
               <Tooltip message="Download as React Components">
-                <Button
-                  variant={ButtonVariants.Icon}
-                  onClick={handleDownloadSelectedAsReact}
-                >
+                <Button variant="icon" onClick={handleDownloadSelectedAsReact}>
                   <Icon icon="filetype-jsx" size={20} />
                   <Icon icon="download" size={20} />
                 </Button>
               </Tooltip>
               <Tooltip message="Download Selected SVGs">
-                <Button
-                  variant={ButtonVariants.Icon}
-                  onClick={handleDownloadSelectedAsSVG}
-                >
+                <Button variant="icon" onClick={handleDownloadSelectedAsSVG}>
                   <Icon icon="filetype-svg" size={20} />
                   <Icon icon="download" size={20} />
                 </Button>
               </Tooltip>
               <Tooltip message="Convert Selected to JSON">
-                <ExportButton
-                  variant={ButtonVariants.Icon}
-                  icons={selectedIcons}
-                >
+                <ExportButton variant="icon" icons={selectedIcons}>
                   <Icon icon="filetype-json" size={20} />
                   <Icon icon="download" size={20} />
                 </ExportButton>
@@ -152,7 +140,7 @@ const IconSetPreviewFooter = ({
             </span>
             {isApp && (
               <Tooltip message="Remove All">
-                <Button variant={ButtonVariants.Icon} onClick={handleRemoveAll}>
+                <Button variant="icon" onClick={handleRemoveAll}>
                   <Icon icon="trash" size={20} />
                 </Button>
               </Tooltip>
@@ -160,7 +148,7 @@ const IconSetPreviewFooter = ({
             {!isApp && (
               <Tooltip message="Send to App">
                 <Button
-                  variant={ButtonVariants.Icon}
+                  variant="icon"
                   className="text-orange-400 hover:text-orange-300"
                   onClick={handleSendToAppAll}
                 >
@@ -169,25 +157,19 @@ const IconSetPreviewFooter = ({
               </Tooltip>
             )}
             <Tooltip message="Download All as React Component">
-              <Button
-                variant={ButtonVariants.Icon}
-                onClick={handleDownloadAllAsReact}
-              >
+              <Button variant="icon" onClick={handleDownloadAllAsReact}>
                 <Icon icon="filetype-jsx" size={20} />
                 <Icon icon="download" size={20} />
               </Button>
             </Tooltip>
             <Tooltip message="Download All">
-              <Button
-                variant={ButtonVariants.Icon}
-                onClick={handleDownloadAllAsSVG}
-              >
+              <Button variant="icon" onClick={handleDownloadAllAsSVG}>
                 <Icon icon="filetype-svg" size={20} />
                 <Icon icon="download" size={20} />
               </Button>
             </Tooltip>
             <Tooltip message="Convert All">
-              <ExportButton variant={ButtonVariants.Icon} icons={icons}>
+              <ExportButton variant="icon" icons={icons}>
                 <Icon icon="filetype-json" size={20} />
                 <Icon icon="download" size={20} />
               </ExportButton>

--- a/src/components/IconSetPreviewHeader.tsx
+++ b/src/components/IconSetPreviewHeader.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 
-import Button, { ButtonVariants } from "src/components/Button";
+import Button from "src/components/Button";
 import SelectVariant from "src/components/SelectVariant";
 import IconSetSearch from "src/components/IconSetSearch";
 import ImportWrapper from "src/components/ImportWrapper";
@@ -41,7 +41,7 @@ const IconSetPreviewHeader = ({
     <div className="flex flex-col items-center justify-between space-y-2 p-4 sm:flex-row">
       {isApp ? (
         <ImportWrapper>
-          <Button variant={ButtonVariants.Primary}>Import</Button>
+          <Button variant="primary">Import</Button>
         </ImportWrapper>
       ) : (
         <div className="flex flex-col text-center sm:text-left">
@@ -71,7 +71,7 @@ const IconSetPreviewHeader = ({
       <div className="flex flex-col-reverse items-center space-x-3 sm:flex-row">
         {!noIcons && (
           <Button
-            variant={ButtonVariants.Ghost}
+            variant="ghost"
             className="text-xs !text-sky-500 hover:!text-sky-600"
             onClick={hasSelectedIcons ? handleDeselectAll : handleSelectAll}
           >

--- a/src/components/IconSetPreviewInspect.tsx
+++ b/src/components/IconSetPreviewInspect.tsx
@@ -1,7 +1,7 @@
 import { useContext, useState, Fragment } from "react";
 import { Dialog, Transition } from "@headlessui/react";
 
-import Button, { ButtonVariants } from "src/components/Button";
+import Button from "src/components/Button";
 import Icon from "src/components/Icon";
 import SelectSize from "src/components/SelectSize";
 import { IconsContext } from "src/context/IconsContext";
@@ -74,7 +74,7 @@ const IconSetPreviewInspect = ({
                     {!isApp && (
                       <Button
                         className="px-0"
-                        variant={ButtonVariants.Ghost}
+                        variant="ghost"
                         onClick={handleSendToApp}
                       >
                         <Icon className="mr-1" icon="window-plus" size={20} />{" "}
@@ -83,7 +83,7 @@ const IconSetPreviewInspect = ({
                     )}
                     <Button
                       className="px-0"
-                      variant={ButtonVariants.Ghost}
+                      variant="ghost"
                       onClick={handleCopyJSX}
                     >
                       <Icon className="mr-1" icon="copy" size={20} /> Copy as
@@ -91,7 +91,7 @@ const IconSetPreviewInspect = ({
                     </Button>
                     <Button
                       className="px-0"
-                      variant={ButtonVariants.Ghost}
+                      variant="ghost"
                       onClick={handleCopySVG}
                     >
                       <Icon className="mr-1" icon="copy" size={20} /> Copy as
@@ -99,7 +99,7 @@ const IconSetPreviewInspect = ({
                     </Button>
                     <Button
                       className="px-0"
-                      variant={ButtonVariants.Ghost}
+                      variant="ghost"
                       onClick={handleDownloadSVG}
                     >
                       <Icon className="mr-1" icon="download" size={20} />{" "}

--- a/src/components/SelectSize.tsx
+++ b/src/components/SelectSize.tsx
@@ -2,7 +2,7 @@ import { Fragment } from "react";
 import { Popover, Transition } from "@headlessui/react";
 
 import Icon from "src/components/Icon";
-import Button, { ButtonVariants } from "src/components/Button";
+import Button from "src/components/Button";
 
 interface SelectSizeProps {
   size: number;
@@ -21,11 +21,11 @@ const SelectSize = ({ size, setSize }: SelectSizeProps) => {
     <Popover className="relative">
       <Popover.Button
         as={Button}
-        variant={ButtonVariants.Ghost}
+        variant="ghost"
         className="w-full px-0 sm:w-auto"
       >
         Size:{" "}
-        <span className="ml-2 text-neutral-900 dark:text-neutral-100 whitespace-nowrap">
+        <span className="ml-2 whitespace-nowrap text-neutral-900 dark:text-neutral-100">
           {size} x {size}
         </span>
         <Icon icon="chevron-down" size={16} className="ml-1"></Icon>

--- a/src/pages/404.tsx
+++ b/src/pages/404.tsx
@@ -2,7 +2,7 @@ import Link from "next/link";
 
 import Header from "src/components/Header";
 import Footer from "src/components/Footer";
-import Button, { ButtonVariants } from "src/components/Button";
+import Button from "src/components/Button";
 
 const PageNotFound = () => (
   <div className="container mx-auto flex h-screen flex-col p-3">
@@ -13,7 +13,7 @@ const PageNotFound = () => (
       </div>
 
       <Link href="/">
-        <Button variant={ButtonVariants.Primary} className="mb-4">
+        <Button variant="primary" className="mb-4">
           Back to home
         </Button>
       </Link>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -2,7 +2,7 @@ import Link from "next/link";
 
 import Header from "src/components/Header";
 import Footer from "src/components/Footer";
-import Button, { ButtonVariants } from "src/components/Button";
+import Button from "src/components/Button";
 import SupportButton from "src/components/SupportButton";
 import Sample from "src/components/Sample";
 import Head from "next/head";
@@ -43,7 +43,7 @@ const HomePage = () => (
               </Button>
             </Link>
             <Link href="/store">
-              <Button variant={ButtonVariants.Ghost} onClick={() => "/store"}>
+              <Button variant="ghost" onClick={() => "/store"}>
                 Explore Store
               </Button>
             </Link>


### PR DESCRIPTION
Improve button components variant system to be able  to:
- Now we dont have to import `variant enums` to  be able to use variants in our Button component.
- No need to add both enums and types to add another variant now. Variants are going to generate by themselves when we add new variant to `variants` object.
- Now we extend `ExportButton`from component `Button`. Reason is;  if we decide to add another prop to our `Button` component we have to add that prop to `ExportButton` as well to make it work. Now we dont have to keep track of `Button` components props because now it will be synced to Button component all the time.