### PR TITLE
Fix notification content z-index

### DIFF
--- a/src/components/Notification.tsx
+++ b/src/components/Notification.tsx
@@ -60,7 +60,7 @@ const Notification = () => {
         leaveFrom="opacity-100 translate-y-0"
         leaveTo="opacity-0 translate-y-1"
       >
-        <Popover.Panel className="absolute right-0 z-10 mt-2 w-60  transform">
+        <Popover.Panel className="absolute right-0 z-50 mt-2 w-60  transform">
           {({ close }) => (
             <div
               className={clsx(


### PR DESCRIPTION
Notification was under content tab and it was resolved.

Before:
<img width="353" alt="Screenshot 2022-12-14 at 07 08 38" src="https://user-images.githubusercontent.com/72952264/207503565-38683ca5-c85f-4514-8ba9-79d1d59c266f.png">

After:
<img width="369" alt="Screenshot 2022-12-14 at 07 08 47" src="https://user-images.githubusercontent.com/72952264/207503576-b9307ca2-1b9f-4d46-99c6-1a0ef76dcde7.png">
