### PR TITLE
Remove trim from target.value

### DIFF
--- a/src/pages/store/index.tsx
+++ b/src/pages/store/index.tsx
@@ -91,7 +91,7 @@ const StorePage = () => {
   }, [searchPageData.currentPage]);
 
   const handleSearch = ({ target }) => {
-    const newValue = target.value.trim();
+    const newValue = target.value;
     if (newValue === search) return;
     setSearch(newValue);
   };


### PR DESCRIPTION
The clipping functionality on the input has been removed to have the same functionality as inputs on different pages.
